### PR TITLE
feat: added support for maxRows

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -128,7 +128,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       this.props.cols,
       // Legacy support for verticalCompact: false
       compactType(this.props),
-      this.props.allowOverlap
+      this.props.allowOverlap,
+      this.props.maxProps,
     ),
     mounted: false,
     oldDragItem: null,
@@ -172,6 +173,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       newLayoutBase = prevState.layout;
     }
 
+    const oldLayoutClone = cloneLayout(prevState.layout);
+
     // We need to regenerate the layout.
     if (newLayoutBase) {
       const newLayout = synchronizeLayoutWithChildren(
@@ -179,13 +182,13 @@ export default class ReactGridLayout extends React.Component<Props, State> {
         nextProps.children,
         nextProps.cols,
         compactType(nextProps),
-        nextProps.allowOverlap
+        nextProps.allowOverlap,
         // don't send maxRows because we don't want to stop first layout (on mount)
-        // nextProps.maxRows
+        nextProps.maxRows
       );
 
       return {
-        layout: newLayout,
+        layout: newLayout || oldLayoutClone,
         // We need to save these props to state for using
         // getDerivedStateFromProps instead of componentDidMount (in which we would get extra rerender)
         compactType: nextProps.compactType,
@@ -351,7 +354,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const l = getLayoutItem(layout, i);
     if (!l) return;
 
-    const oldLayoutClone = cloneLayout(layout);
+    const { oldLayout } = this.state;
+    const oldLayoutClone = cloneLayout(oldLayout);
 
     // Move the element here
     const isUserAction = true;
@@ -383,7 +387,6 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.props.onDragStop(newLayout, oldDragItem, l, null, e, node);
 
-    const { oldLayout } = this.state;
     this.setState({
       activeDrag: null,
       layout: newLayout,
@@ -547,7 +550,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const { cols, allowOverlap, maxRows } = this.props;
     const l = getLayoutItem(layout, i);
 
-    const oldLayoutClone = cloneLayout(layout);
+    const { oldLayout } = this.state;
+    const oldLayoutClone = cloneLayout(oldLayout);
 
     let compactedLayout = compact(
       layout,
@@ -565,7 +569,6 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.props.onResizeStop(newLayout, oldResizeItem, l, null, e, node);
 
-    const { oldLayout } = this.state;
     this.setState({
       activeDrag: null,
       layout: newLayout,

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -175,7 +175,7 @@ export default class ResponsiveReactGridLayout extends React.Component<
   state: State = this.generateInitialState();
 
   generateInitialState(): State {
-    const { width, breakpoints, layouts, cols } = this.props;
+    const { width, breakpoints, layouts, cols, maxRows } = this.props;
     const breakpoint = getBreakpointFromWidth(breakpoints, width);
     const colNo = getColsFromBreakpoint(breakpoint, cols);
     // verticalCompact compatibility, now deprecated
@@ -189,7 +189,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
       breakpoint,
       breakpoint,
       colNo,
-      compactType
+      compactType,
+      maxRows
     );
 
     return {
@@ -215,7 +216,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
         breakpoint,
         breakpoint,
         cols,
-        nextProps.compactType
+        nextProps.compactType,
+        nextProps.maxRows
       );
       return { layout: newLayout, layouts: nextProps.layouts };
     }
@@ -248,7 +250,7 @@ export default class ResponsiveReactGridLayout extends React.Component<
    * Width changes are necessary to figure out the widget widths.
    */
   onWidthChange(prevProps: Props<*>) {
-    const { breakpoints, cols, layouts, compactType } = this.props;
+    const { breakpoints, cols, layouts, compactType, maxRows } = this.props;
     const newBreakpoint =
       this.props.breakpoint ||
       getBreakpointFromWidth(this.props.breakpoints, this.props.width);
@@ -274,7 +276,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
         newBreakpoint,
         lastBreakpoint,
         newCols,
-        compactType
+        compactType,
+        maxRows
       );
 
       // This adds missing items.

--- a/lib/responsiveUtils.js
+++ b/lib/responsiveUtils.js
@@ -80,7 +80,8 @@ export function findOrGenerateResponsiveLayout(
   breakpoint: Breakpoint,
   lastBreakpoint: Breakpoint,
   cols: number,
-  compactType: CompactType
+  compactType: CompactType,
+  maxRows: ?number
 ): Layout {
   // If it already exists, just return it.
   if (layouts[breakpoint]) return cloneLayout(layouts[breakpoint]);
@@ -98,7 +99,21 @@ export function findOrGenerateResponsiveLayout(
     }
   }
   layout = cloneLayout(layout || []); // clone layout so we don't modify existing items
-  return compact(correctBounds(layout, { cols: cols }), compactType, cols);
+
+  const oldLayoutClone = cloneLayout(layout);
+
+  layout = compact(
+    correctBounds(layout, { cols: cols }),
+    compactType,
+    cols,
+    0,
+    maxRows
+  );
+
+  if (!layout.length) {
+    layout = oldLayoutClone;
+  }
+  return layout;
 }
 
 /**

--- a/lib/responsiveUtils.js
+++ b/lib/responsiveUtils.js
@@ -110,7 +110,7 @@ export function findOrGenerateResponsiveLayout(
     maxRows
   );
 
-  if (!layout.length) {
+  if (!layout?.length) {
     layout = oldLayoutClone;
   }
   return layout;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -945,15 +945,13 @@ export function synchronizeLayoutWithChildren(
   // Correct the layout.
   const correctedLayout = correctBounds(layout, { cols: cols });
 
-  let compactedLayout = compact(
+  const compactedLayout = compact(
     correctedLayout,
     compactType,
     cols,
     allowOverlap,
     maxRows
   );
-
-  compactedLayout = compactedLayout || correctedLayout;
 
   return allowOverlap ? correctedLayout : compactedLayout;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -235,7 +235,8 @@ export function compact(
   layout: Layout,
   compactType: CompactType,
   cols: number,
-  allowOverlap: ?boolean
+  allowOverlap: ?boolean,
+  maxRows: ?number
 ): Layout {
   // Statics go in the compareWith array right away so items flow around them.
   const compareWith = getStatics(layout);
@@ -249,7 +250,20 @@ export function compact(
 
     // Don't move static elements
     if (!l.static) {
-      l = compactItem(compareWith, l, compactType, cols, sorted, allowOverlap);
+      l = compactItem(
+        compareWith,
+        l,
+        compactType,
+        cols,
+        sorted,
+        allowOverlap,
+        maxRows
+      );
+
+      // if l is null, the caller will revert the layout and keep the item in the same place.
+      if (!l) {
+        return null;
+      }
 
       // Add to comparison array. We only collide with items before this one.
       // Statics are already in this array.
@@ -319,7 +333,8 @@ export function compactItem(
   compactType: CompactType,
   cols: number,
   fullLayout: Layout,
-  allowOverlap: ?boolean
+  allowOverlap: ?boolean,
+  maxRows: ?number
 ): LayoutItem {
   const compactV = compactType === "vertical";
   const compactH = compactType === "horizontal";
@@ -365,6 +380,12 @@ export function compactItem(
   // Ensure that there are no negative positions
   l.y = Math.max(l.y, 0);
   l.x = Math.max(l.x, 0);
+
+  // if maxRows is defined, the layout must not go beyond that height
+  // return null if it goes, so the caller will revert the changes
+  if (l.y + l.h > maxRows) {
+    return null;
+  }
 
   return l;
 }
@@ -880,7 +901,8 @@ export function synchronizeLayoutWithChildren(
   children: ReactChildren,
   cols: number,
   compactType: CompactType,
-  allowOverlap: ?boolean
+  allowOverlap: ?boolean,
+  maxRows: ?number
 ): Layout {
   initialLayout = initialLayout || [];
 
@@ -922,9 +944,18 @@ export function synchronizeLayoutWithChildren(
 
   // Correct the layout.
   const correctedLayout = correctBounds(layout, { cols: cols });
-  return allowOverlap
-    ? correctedLayout
-    : compact(correctedLayout, compactType, cols);
+
+  let compactedLayout = compact(
+    correctedLayout,
+    compactType,
+    cols,
+    allowOverlap,
+    maxRows
+  );
+
+  compactedLayout = compactedLayout || correctedLayout;
+
+  return allowOverlap ? correctedLayout : compactedLayout;
 }
 
 /**


### PR DESCRIPTION
This commit improves the responsive layout generation by adding support for a `maxRows` parameter. The `findOrGenerateResponsiveLayout` function in `responsiveUtils.js` and the `generateInitialState` function in `ResponsiveReactGridLayout.jsx` now accept a `maxRows` parameter and use it to limit the height of the layout. The `compact` and `compactItem` functions in `utils.js` have also been updated to handle the `maxRows` parameter.

This change addresses the issue where the layout could exceed the specified maximum number of rows. It ensures that the layout is compacted and adjusted to fit within the specified constraints.

Ref: #657

## Description

<!--
Don't leave this blank! Tell us what this PR is about, what it fixes, or what it adds.
-->

This PR fixes the bug 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature

## Related Tickets & Documents
Fixes #2044
Reference PR #657

## Mobile & Desktop Screenshots/Recordings
![react-grid-layout-ezgif com-video-to-gif-converter](https://github.com/parth-chovatiya/react-grid-layout/assets/22892193/e09f50d3-0234-4953-9001-cc200ae87789)

## Added tests?
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 examples
- [ ] 🙅 no documentation needed
